### PR TITLE
Divider isn’t rainbow

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,9 @@ def main():
     header_col, metric_column = st.columns([7,1])
     with header_col:
         # Artzy Heading with Rainbow divider underneath!
-        st.header("Artzy", divider="violet")
+        st.header("Welcome to Artzy")
+        st.subheader("-where Art meet Innovation & Collaboration")
+        st.header(divider = "rainbow")
     with metric_column: 
         st.metric(label="Generated",value=get_number_of_sketches(), delta="sketches")
 


### PR DESCRIPTION
It said that the divider is rainbow in hashtags but it is violet so I changed it to rainbow, I put welcome to Artzy instead of Artzy to seem more welcoming, and I added “-where Art meets Innovation & Collaboration” as a caption.